### PR TITLE
fix: 🐛 make pfv mock responsive to bots again

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -143,8 +143,6 @@ https://github.com/golangis/botinha.py
     elif m.startswith('pfv link') or m.startswith('pfv invite'):
         await msg.reply('https://discord.gg/bQp7H5vpcX')
     elif m.startswith('pfv mock '):
-        if msg.author.bot:
-            return
         final_mock = "".join(random.choice([letter_mock.lower(), letter_mock.upper()]) for letter_mock in m[8:])
         await msg.channel.send(final_mock + ' <:mock:820984871152648232>')
     elif m.startswith('pls mock'):


### PR DESCRIPTION
This commit removes an if statement that was added in #1.

![image](https://user-images.githubusercontent.com/13498603/111776110-85c40a00-88a9-11eb-9de1-ff38b25691b7.png)

As you can see, those changes were not taken well by the community and I seriously think you should consider reverting them :D